### PR TITLE
Adicionado restante dos tratamentos de login que faltava

### DIFF
--- a/Views/LoginViewModel.cs
+++ b/Views/LoginViewModel.cs
@@ -91,10 +91,19 @@ namespace GNAutoRota.Views
                 {
                    case "invalid_email":
                         {
-                            await App.Current.MainPage.DisplayAlert("Alerta", "email inválido", "Ok");
+                            await App.Current.MainPage.DisplayAlert("Alerta", "Email inválido", "Ok");
                             break;
                         }
-
+                   case "missing_password":
+                        {
+                            await App.Current.MainPage.DisplayAlert("Alerta", "Falta adicionar uma senha", "Ok");
+                            break;
+                        }
+                   case "invalid_login_credentials":
+                        {
+                            await App.Current.MainPage.DisplayAlert("Alerta", "Email ou senha incorretos", "Ok");
+                            break;
+                        }
                 }
             }
             


### PR DESCRIPTION
Posteriormente, trocar o método display alert por outro método que não precise de uma confirmação do usuário para prosseguir.